### PR TITLE
Add suites section and abstract group interface.

### DIFF
--- a/draft-schlesinger-cfrg-act.md
+++ b/draft-schlesinger-cfrg-act.md
@@ -354,10 +354,10 @@ domain_separator = "ACT-v1:" || organization || ":" || service || ":" || deploym
 
 where:
 
-- `organization`: A unique identifier for the organization (e.g., "example-corp", "acme-inc")
-- `service`: The specific service or application name (e.g., "payment-api", "rate-limiter")
-- `deployment_id`: The deployment environment (e.g., "production", "staging", "us-west-1")
-- `version`: An ISO 8601 date (YYYY-MM-DD) indicating when parameters were generated
+- `organization`: A unique identifier for the organization (e.g., "example-corp", "acme-inc").
+- `service`: The specific service or application name (e.g., "payment-api", "rate-limiter").
+- `deployment_id`: The deployment environment (e.g., "production", "staging", "us-west-1").
+- `version`: An ISO 8601 date (YYYY-MM-DD) indicating when parameters were generated.
 
 Example: `"ACT-v1:example-corp:payment-api:production:2024-01-15"`
 


### PR DESCRIPTION
This brings a section for ACT suites. Currently only ristretto group is allowed. 
This avoids to add the boilerplate text for groups by just making a reference to the VOPRF draft.
Also redefines how to build the additonal generators based on a generic HashToGroup function.

Fixes #1 
Fixes #3 

On top of https://github.com/SamuelSchlesinger/draft-act/pull/12